### PR TITLE
fix(preloader.js): Declaração da classe 'body'

### DIFF
--- a/public/js/preloader.js
+++ b/public/js/preloader.js
@@ -14,7 +14,7 @@ window.scrollTo({ top: 0, behavior: 'smooth' });
 setTimeout(() => {
     preloader.style.opacity = '0';
     setTimeout(() => {
-        body.classList.remove('no-scroll');
+        document.body.classList.remove('no-scroll');
         preloader.style.display = 'none';
     }, 300);
 }, 1100);


### PR DESCRIPTION
Corrige o código do preloader.js onde a remoção da classe 'no-scroll' foi atualizada para document.body.classList.remove('no-scroll'). Essa correção é necessária porque a referência ao elemento body não foi declarada como uma variável, e portanto, é preciso utilizar document.body para acessá-lo corretamente.